### PR TITLE
Remove accented character from contributors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1198,7 +1198,7 @@ Contributors
 
 - Marco Lempen
 
-- Attila Oláh
+- Attila Olah
 
 
 Credits


### PR DESCRIPTION
I came across an odd issue when plumber was brought in as a dependency during a `pip install`. This was with python 3.3, 3.4 and 3.5.

```
  Downloading plumber-1.3.1.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-ct7e7g23/plumber/setup.py", line 8, in <module>
        longdesc = open(os.path.join(os.path.dirname(__file__), 'README.rst')).read()
      File "/opt/rh/rh-python35/root/usr/lib64/python3.5/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 35717: ordinal not in range(128)
```

The solution I came across was to remove the accented character from Attila Oláh's name. I know it seems a bit mean to change someones name :(. The alternative is to change the long_description in the `setup.py` to not require the whole readme file.